### PR TITLE
Error with stop

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "eslint-plugin-import": "2.14.0",
         "eslint-plugin-jsx-a11y": "6.1.2",
         "eslint-plugin-react": "7.11.1",
-        "ezs": "6.0.0",
+        "ezs": "6.1.0",
         "feed": "2.0.1",
         "from": "0.1.7",
         "jest": "23.6.0"

--- a/src/convertJsonLdToNQuads.js
+++ b/src/convertJsonLdToNQuads.js
@@ -19,8 +19,8 @@ export default function convertJsonLdToNQuads(data, feed) {
             (err, nquads) => {
                 if (err) {
                     // eslint-disable-next-line no-console
-                    console.error('toRDF: ', err);
-                    throw new Error(err);
+                    console.error('convertJsonLdToNQuads: ', err);
+                    feed.stop(new Error(err));
                 }
                 feed.send(nquads);
             },

--- a/test/convertJsonLdToNQuads.spec.js
+++ b/test/convertJsonLdToNQuads.spec.js
@@ -48,7 +48,7 @@ describe('convertJSonLdToNquads', () => {
 
     // There is still a bug in error management in ezs@6.0.0
     // Wait for a fix to remove .skip
-    it.skip('should throw when error', (done) => {
+    it('should throw when error', (done) => {
         // see https://json-ld.org/playground/ for the Person example
         from([{
             '@context': 'http://schema.org/',
@@ -69,9 +69,6 @@ describe('convertJSonLdToNquads', () => {
             })
             .on('data', (data) => {
                 expect(data).not.toBeDefined();
-            })
-            .on('end', () => {
-                done(new Error('Should not work'));
             });
     },
     8000);


### PR DESCRIPTION
Thanks to the last version of ezs (6.1.0), we can pass errors to the feed, from an asynchronous statement.

Let's unskip the test (and rewrite the convertJsonLdToNQuads to be compliant with the new `stop` function).