### PR TITLE
Adapt input structure of convertToExtendedJsonLd

### DIFF
--- a/src/convertToExtendedJsonLd.js
+++ b/src/convertToExtendedJsonLd.js
@@ -108,17 +108,17 @@ export default function convertToExtendedJsonLd(data, feed) {
     if (!this.searchKeys) {
         this.context = getContext(config, prefixes);
         this.searchKeys = Object.keys(this.context).filter(
-            v => !Object.keys(data.content).includes(v) && v !== config.istexQuery.linked,
+            v => !Object.keys(data).includes(v) && v !== config.istexQuery.linked,
         );
     }
     const newHit = {
-        ...data.content,
+        ...data,
     };
-    newHit['@id'] = `https://api.istex.fr/${data.content.arkIstex}`;
-    newHit[config.istexQuery.linked] = data.lodex.uri;
+    newHit['@id'] = `https://api.istex.fr/${data.arkIstex}`;
+    newHit[config.istexQuery.linked] = data.uri;
 
     this.searchKeys.forEach((key) => {
-        const dataFromKey = get(data.content, key);
+        const dataFromKey = get(data, key);
         newHit[key] = formatData(dataFromKey);
     });
 

--- a/test/convertToExtendedJsonLd.spec.js
+++ b/test/convertToExtendedJsonLd.spec.js
@@ -12,27 +12,25 @@ describe('conversion to extended JSON-LD', () => {
     beforeEach(() => {
         dataTest = [
             {
-                lodex: { uri: 'http://localhost:3000/ark:/67375/RZL-F4841DSB-1' },
-                content: {
-                    arkIstex: 'ark:/67375/6H6-N49F7FRR-Q',
-                    doi: ['10.1006/jmaa.2001.7542'],
-                    fulltext: [
-                        {
-                            extension: 'pdf',
-                            original: true,
-                            mimetype: 'application/pdf',
-                            uri:
-                                'https://api.istex.fr/document/9AA9EE9B75A6067C28F8119813504932FFD3D5A1/fulltext/pdf',
-                        },
-                        {
-                            extension: 'zip',
-                            original: false,
-                            mimetype: 'application/zip',
-                            uri:
-                                'https://api.istex.fr/document/9AA9EE9B75A6067C28F8119813504932FFD3D5A1/fulltext/zip',
-                        },
-                    ],
-                },
+                uri: 'http://localhost:3000/ark:/67375/RZL-F4841DSB-1',
+                arkIstex: 'ark:/67375/6H6-N49F7FRR-Q',
+                doi: ['10.1006/jmaa.2001.7542'],
+                fulltext: [
+                    {
+                        extension: 'pdf',
+                        original: true,
+                        mimetype: 'application/pdf',
+                        uri:
+                            'https://api.istex.fr/document/9AA9EE9B75A6067C28F8119813504932FFD3D5A1/fulltext/pdf',
+                    },
+                    {
+                        extension: 'zip',
+                        original: false,
+                        mimetype: 'application/zip',
+                        uri:
+                            'https://api.istex.fr/document/9AA9EE9B75A6067C28F8119813504932FFD3D5A1/fulltext/zip',
+                    },
+                ],
             },
         ];
         expectedJsonLd = {
@@ -218,7 +216,7 @@ describe('conversion to extended JSON-LD', () => {
     });
 
     it('should use formatData when array', (done) => {
-        dataTest[0].content.a = [['a']];
+        dataTest[0].a = [['a']];
         expectedJsonLd['@graph'][0].a = [['a']];
         expectedJsonLd['@graph'][0]['a[0]'] = ['a'];
         config.istexQuery.context['a[0]'] = 'http://a#';

--- a/test/convertToExtendedJsonLd.spec.js
+++ b/test/convertToExtendedJsonLd.spec.js
@@ -69,6 +69,7 @@ describe('conversion to extended JSON-LD', () => {
                         '@id':
                             'https://api.istex.fr/document/9AA9EE9B75A6067C28F8119813504932FFD3D5A1/fulltext/pdf',
                     },
+                    uri: 'http://localhost:3000/ark:/67375/RZL-F4841DSB-1',
                 },
             ],
         };


### PR DESCRIPTION
Because of https://github.com/Inist-CNRS/lodex-extented/pull/3, simplify structure, and go from

```json
{
  "lodex": {
    "uri": "http://uri"
  },
  "content": {
    "arkIstex": "...",
    "id": "..."
  }
}
```

to 

```json
{
  "uri": "http://uri",
  "arkIstex": "...",
  "id": "..."
}
```
which is now ISTEXResult's output structure.