### PR TITLE
Add convertNQuadsToTurtle statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ process.stdin
     -   [Parameters](#parameters-3)
     -   [Examples](#examples-2)
 -   [objects2columns](#objects2columns)
+-   [parseNQuads](#parsenquads)
+-   [writeTurtle](#writeturtle)
+    -   [Examples](#examples-3)
 
 ## convertJsonLdToNQuads
 
@@ -195,3 +198,69 @@ Returns **any** Same object with modified keys
 Take `Object` and ...
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+## parseNQuads
+
+Take N-Quads string and transform it to Objects.
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+## writeTurtle
+
+Take quad or prefixes object and return turtle string.
+
+### Examples
+
+Input:
+
+
+```javascript
+[{
+   quad: {
+     subject: { id: 'http://uri/janedoe' },
+     predicate: { id: 'http://schema.org/jobTitle' },
+     object: { id: '"Professor"' }
+   }
+ }, {
+     quad: {
+     subject: { id: 'http://uri/janedoe' },
+     predicate: { id: 'http://schema.org/name' },
+     object: { id: '"Jane Doe"' }
+   }
+ }, {
+     quad: Quad {
+     subject: { id: 'http://uri/janedoe' },
+     predicate: { id: 'http://schema.org/telephone' },
+     object: { id: '"(425) 123-4567"' }
+     }
+ }, {
+     quad: Quad {
+     subject: { id: 'http://uri/janedoe' },
+     predicate: { id: 'http://schema.org/url' },
+     object: { id: 'http://www.janedoe.com' }
+     }
+ }, {
+     quad: Quad {
+     subject: { id: 'http://uri/janedoe' },
+     predicate: { id: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type' },
+     object: { id: 'http://schema.org/Person' }
+     }
+ }, { prefixes: {} }
+ ]
+```
+
+Output:
+
+
+```javascript
+'@prefix schema: <http://schema.org/>.\n'
+'@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.\n'
+'\n'
+'<http://uri/janedoe> schema:jobTitle "Professor";\n'
+'    schema:name "Jane Doe";\n'
+'    schema:telephone "(425) 123-4567";\n'
+'    schema:url <http://www.janedoe.com>;\n'
+'    a schema:Person.\n"'
+```
+
+Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** turtle

--- a/package-lock.json
+++ b/package-lock.json
@@ -9892,6 +9892,11 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
+    "n3": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.1.1.tgz",
+      "integrity": "sha512-GEJXn+wc0f4l2noP1N/rMUH9Gei1DQ8IDN03eBsH+uQKkNQUOLgL7ZJVaDjY+pP3LmbLxL1LpUg/AvZ7Kc7KVw=="
+    },
     "nan": {
       "version": "2.11.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "lodash.unset": "4.5.2",
         "lodash.zipobject": "4.1.3",
         "mongodb": "3.1.13",
+        "n3": "1.1.1",
         "node-object-hash": "1.4.2",
         "valid-url": "1.0.9",
         "xml-writer": "1.7.0"

--- a/prefixes.json
+++ b/prefixes.json
@@ -1,0 +1,21 @@
+{
+    "bibo": "http://purl.org/ontology/bibo/",
+    "dbpedia": "http://dbpedia.org/ontology/",
+    "dcdoc": "http://dublincore.org/documents/",
+    "dcmitype": "http://purl.org/dc/dcmitype/",
+    "dcterms": "http://purl.org/dc/terms/",
+    "foaf": "http://xmlns.com/foaf/0.1/#",
+    "geo": "http://www.w3.org/2003/01/geo/wgs84_pos#",
+    "gn": "http://www.geonames.org/ontology/ontology_v3.1.rdf/",
+    "istex": "https://data.istex.fr/ontology/istex#",
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "prov": "http://www.w3.org/ns/prov#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "schema": "http://schema.org/",
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "time": "http://www.w3.org/TR/owl-time/",
+    "xfoaf": "http://www.foafrealm.org/xfoaf/0.1/",
+    "xml": "http://www.w3.org/XML/1998/namespace",
+    "xsd": "http://www.w3.org/2001/XMLSchema#"
+}

--- a/src/convertToExtendedJsonLd.js
+++ b/src/convertToExtendedJsonLd.js
@@ -2,27 +2,7 @@ import validUrl from 'valid-url';
 import get from 'lodash.get';
 
 // import prefixes from '../../common/prefixes'; // IN LODEX
-const defaultPrefixes = {
-    bibo: 'http://purl.org/ontology/bibo/',
-    dbpedia: 'http://dbpedia.org/ontology/',
-    dcdoc: 'http://dublincore.org/documents/',
-    dcmitype: 'http://purl.org/dc/dcmitype/',
-    dcterms: 'http://purl.org/dc/terms/',
-    foaf: 'http://xmlns.com/foaf/0.1/#',
-    geo: 'http://www.w3.org/2003/01/geo/wgs84_pos#',
-    gn: 'http://www.geonames.org/ontology/ontology_v3.1.rdf/',
-    istex: 'https://data.istex.fr/ontology/istex#',
-    owl: 'http://www.w3.org/2002/07/owl#',
-    prov: 'http://www.w3.org/ns/prov#',
-    rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
-    rdfs: 'http://www.w3.org/2000/01/rdf-schema#',
-    schema: 'http://schema.org/',
-    skos: 'http://www.w3.org/2004/02/skos/core#',
-    time: 'http://www.w3.org/TR/owl-time/',
-    xfoaf: 'http://www.foafrealm.org/xfoaf/0.1/',
-    xml: 'http://www.w3.org/XML/1998/namespace',
-    xsd: 'http://www.w3.org/2001/XMLSchema#',
-};
+import defaultPrefixes from '../prefixes.json';
 
 /*
  * Create a JSONLD context with prefixes and istexQuery informations in config.json

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,8 @@ import reduceQuery from './reduceQuery';
 import formatOutput from './formatOutput';
 import getLastCharacteristic from './getLastCharacteristic';
 import keyMapping from './keyMapping';
+import parseNQuads from './parseNQuads';
+import writeTurtle from './writeTurtle';
 
 export default {
     flattenPatch,
@@ -41,6 +43,8 @@ export default {
     runQuery,
     reduceQuery,
     formatOutput,
+    parseNQuads,
+    writeTurtle,
     // aliases
     fixFlatten: flattenPatch.flattenPatch,
     LodexContext: disabled.disabled,

--- a/src/parseNQuads.js
+++ b/src/parseNQuads.js
@@ -1,0 +1,28 @@
+import { Parser } from 'n3';
+
+/**
+ * Take N-Quads string and transform it to Objects.
+ *
+ * @name parseNQuads
+ * @param none.
+ * @returns {Object}
+ */
+export default function parseNQuads(data, feed) {
+    if (this.isLast()) {
+        return feed.close();
+    }
+
+    if (this.isFirst()) {
+        this.parser = new Parser({ format: 'N-Quads' });
+    }
+
+    return this.parser.parse(data, (error, quad, prefixes) => {
+        if (error) {
+            return feed.stop(new Error(error));
+        }
+        if (!quad) {
+            return feed.send({ prefixes });
+        }
+        return feed.write({ quad });
+    });
+}

--- a/src/writeTurtle.js
+++ b/src/writeTurtle.js
@@ -1,0 +1,40 @@
+import { Store, Writer } from 'n3';
+
+/**
+ * Take quad or prefixes object and return turtle string.
+ *
+ * @export
+ * @return {String} turtle
+ * @name writeTurtle
+ */
+export default function writeTurtle(data, feed) {
+    const defaultPrefixes = {
+        schema: 'http://schema.org/',
+    };
+    if (this.isLast()) {
+        feed.close();
+        return;
+    }
+    if (this.isFirst()) {
+        this.store = new Store();
+    }
+    if (data && data.quad) {
+        const { quad } = data;
+        this.store.addQuad(quad);
+    }
+    if (data && data.prefixes) {
+        const { prefixes } = data;
+        this.writer = new Writer({ prefixes: { ...defaultPrefixes, prefixes } });
+        const quads = this.store.getQuads();
+        this.writer.addQuads(quads);
+        this.writer.end((error, result) => {
+            if (error) {
+                return feed.stop(new Error(error));
+            }
+            return feed.send(result);
+        });
+        this.store = null;
+        this.writer = null;
+    }
+    feed.end();
+}

--- a/src/writeTurtle.js
+++ b/src/writeTurtle.js
@@ -7,6 +7,50 @@ const uriPrefixes = Object.values(defaultPrefixes);
 /**
  * Take quad or prefixes object and return turtle string.
  *
+ * @example <caption>Input:</caption>
+ * [{
+ *    quad: {
+ *      subject: { id: 'http://uri/janedoe' },
+ *      predicate: { id: 'http://schema.org/jobTitle' },
+ *      object: { id: '"Professor"' }
+ *    }
+ *  }, {
+ *      quad: {
+ *      subject: { id: 'http://uri/janedoe' },
+ *      predicate: { id: 'http://schema.org/name' },
+ *      object: { id: '"Jane Doe"' }
+ *    }
+ *  }, {
+ *      quad: Quad {
+ *      subject: { id: 'http://uri/janedoe' },
+ *      predicate: { id: 'http://schema.org/telephone' },
+ *      object: { id: '"(425) 123-4567"' }
+ *      }
+ *  }, {
+ *      quad: Quad {
+ *      subject: { id: 'http://uri/janedoe' },
+ *      predicate: { id: 'http://schema.org/url' },
+ *      object: { id: 'http://www.janedoe.com' }
+ *      }
+ *  }, {
+ *      quad: Quad {
+ *      subject: { id: 'http://uri/janedoe' },
+ *      predicate: { id: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type' },
+ *      object: { id: 'http://schema.org/Person' }
+ *      }
+ *  }, { prefixes: {} }
+ *  ]
+ *
+ * @example <caption>Output:</caption>
+ * '@prefix schema: <http://schema.org/>.\n'
+ * '@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.\n'
+ * '\n'
+ * '<http://uri/janedoe> schema:jobTitle "Professor";\n'
+ * '    schema:name "Jane Doe";\n'
+ * '    schema:telephone "(425) 123-4567";\n'
+ * '    schema:url <http://www.janedoe.com>;\n'
+ * '    a schema:Person.\n"'
+ *
  * @export
  * @return {String} turtle
  * @name writeTurtle

--- a/test/convertNQuadsToTurtle.spec.js
+++ b/test/convertNQuadsToTurtle.spec.js
@@ -7,6 +7,7 @@ ezs.use(statements);
 
 describe('convertNQuadsToTurtle', () => {
     it('should convert N-Quads to turtle', (done) => {
+        let res = '';
         from([[
             '<http://uri/janedoe> <http://schema.org/jobTitle> "Professor" .',
             '<http://uri/janedoe> <http://schema.org/name> "Jane Doe" .',
@@ -14,20 +15,24 @@ describe('convertNQuadsToTurtle', () => {
             '<http://uri/janedoe> <http://schema.org/url> <http://www.janedoe.com> .',
             '<http://uri/janedoe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Person> .',
         ].join('\n')])
-            .pipe(ezs('convertNQuadsToTurtle'))
+            .pipe(ezs('parseNQuads'))
+            .pipe(ezs('writeTurtle'))
             .on('data', (data) => {
-                expect(data).toEqual([
-                    '@prefix schema: <http://schema.org/> .',
+                res += data;
+            })
+            .on('end', () => {
+                expect(res).toEqual([
+                    '@prefix schema: <http://schema.org/>.',
                     '',
-                    '<http://uri/janedoe>',
-                    '  schema:jobTitle "Professor" ;',
-                    '  schema:name "Jane Doe" ;',
-                    '  schema:telephone "(425) 123-4567" ;',
-                    '  schema:url <http://www.janedoe.com> ;',
-                    '  a schema:Person .',
+                    '<http://uri/janedoe> schema:jobTitle "Professor";',
+                    '    schema:name "Jane Doe";',
+                    '    schema:telephone "(425) 123-4567";',
+                    '    schema:url <http://www.janedoe.com>;',
+                    '    a schema:Person.',
                     '',
                 ].join('\n'));
                 done();
-            });
+            })
+            .on('error', done);
     });
 });

--- a/test/convertNQuadsToTurtle.spec.js
+++ b/test/convertNQuadsToTurtle.spec.js
@@ -1,0 +1,33 @@
+import ezs from 'ezs';
+import from from 'from';
+
+import statements from '../src';
+
+ezs.use(statements);
+
+describe('convertNQuadsToTurtle', () => {
+    it('should convert N-Quads to turtle', (done) => {
+        from([[
+            '<http://uri/janedoe> <http://schema.org/jobTitle> "Professor" .',
+            '<http://uri/janedoe> <http://schema.org/name> "Jane Doe" .',
+            '<http://uri/janedoe> <http://schema.org/telephone> "(425) 123-4567" .',
+            '<http://uri/janedoe> <http://schema.org/url> <http://www.janedoe.com> .',
+            '<http://uri/janedoe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Person> .',
+        ].join('\n')])
+            .pipe(ezs('convertNQuadsToTurtle'))
+            .on('data', (data) => {
+                expect(data).toEqual([
+                    '@prefix schema: <http://schema.org/> .',
+                    '',
+                    '<http://uri/janedoe>',
+                    '  schema:jobTitle "Professor" ;',
+                    '  schema:name "Jane Doe" ;',
+                    '  schema:telephone "(425) 123-4567" ;',
+                    '  schema:url <http://www.janedoe.com> ;',
+                    '  a schema:Person .',
+                    '',
+                ].join('\n'));
+                done();
+            });
+    });
+});

--- a/test/convertNQuadsToTurtle.spec.js
+++ b/test/convertNQuadsToTurtle.spec.js
@@ -36,42 +36,4 @@ describe('convertNQuadsToTurtle', () => {
             })
             .on('error', done);
     });
-
-    it('should accept prefix parameters', (done) => {
-        let res = '';
-        from([[
-            '<http://uri/janedoe> <http://schema.org/jobTitle> "Professor" .',
-            '<http://uri/janedoe> <http://schema.org/name> "Jane Doe" .',
-            '<http://uri/janedoe> <http://schema.org/telephone> "(425) 123-4567" .',
-            '<http://uri/janedoe> <http://schema.org/url> <http://www.janedoe.com> .',
-            '<http://uri/janedoe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Person> .',
-        ].join('\n')])
-            .pipe(ezs('delegate', {
-                script: `
-                    [parseNQuads]
-                    [debug]
-                    [writeTurtle]
-                    prefix = istex
-                    uri = https://data.istex.fr/ontology/istex#
-                `,
-            }))
-            .on('data', (data) => {
-                res += data;
-            })
-            .on('end', () => {
-                expect(res).toEqual([
-                    '@prefix schema: <http://schema.org/>.',
-                    '@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.',
-                    '',
-                    '<http://uri/janedoe> schema:jobTitle "Professor";',
-                    '    schema:name "Jane Doe";',
-                    '    schema:telephone "(425) 123-4567";',
-                    '    schema:url <http://www.janedoe.com>;',
-                    '    a schema:Person.',
-                    '',
-                ].join('\n'));
-                done();
-            })
-            .on('error', done);
-    });
 });

--- a/test/convertNQuadsToTurtle.spec.js
+++ b/test/convertNQuadsToTurtle.spec.js
@@ -23,6 +23,45 @@ describe('convertNQuadsToTurtle', () => {
             .on('end', () => {
                 expect(res).toEqual([
                     '@prefix schema: <http://schema.org/>.',
+                    '@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.',
+                    '',
+                    '<http://uri/janedoe> schema:jobTitle "Professor";',
+                    '    schema:name "Jane Doe";',
+                    '    schema:telephone "(425) 123-4567";',
+                    '    schema:url <http://www.janedoe.com>;',
+                    '    a schema:Person.',
+                    '',
+                ].join('\n'));
+                done();
+            })
+            .on('error', done);
+    });
+
+    it('should accept prefix parameters', (done) => {
+        let res = '';
+        from([[
+            '<http://uri/janedoe> <http://schema.org/jobTitle> "Professor" .',
+            '<http://uri/janedoe> <http://schema.org/name> "Jane Doe" .',
+            '<http://uri/janedoe> <http://schema.org/telephone> "(425) 123-4567" .',
+            '<http://uri/janedoe> <http://schema.org/url> <http://www.janedoe.com> .',
+            '<http://uri/janedoe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Person> .',
+        ].join('\n')])
+            .pipe(ezs('delegate', {
+                script: `
+                    [parseNQuads]
+                    [debug]
+                    [writeTurtle]
+                    prefix = istex
+                    uri = https://data.istex.fr/ontology/istex#
+                `,
+            }))
+            .on('data', (data) => {
+                res += data;
+            })
+            .on('end', () => {
+                expect(res).toEqual([
+                    '@prefix schema: <http://schema.org/>.',
+                    '@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.',
                     '',
                     '<http://uri/janedoe> schema:jobTitle "Professor";',
                     '    schema:name "Jane Doe";',


### PR DESCRIPTION
The aim is to provide a way to convert NQuads to Turtle.

But the inspiration is https://github.com/Inist-CNRS/lodex/blob/ac7ae53900b8b8d834048102ea80edfeca691205/src/api/exporters/exportTurtle.js#L31-L36, which is easier to rewrite as two ezs statements: `parseNQuads` and `writeTurtle`.